### PR TITLE
Avoid partial name matching

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -33,7 +33,7 @@ get_contributors <- function (org, repo,
         repo,
         alphabetical = alphabetical
     )
-    ctb_code <- ctb_code [which (!is.na (ctb_code$login)), ]
+    ctb_code <- ctb_code [which (!is.na (ctb_code$logins)), ]
     ctb_code$type <- "code"
     if (!quiet) {
         message (
@@ -59,12 +59,12 @@ get_contributors <- function (org, repo,
             exclude_not_planned = exclude_not_planned
         )
 
-        index <- which (!ctb_issues$authors$login %in% ctb_code$logins)
+        index <- which (!ctb_issues$authors$logins %in% ctb_code$logins)
         ctb_issues$authors <- ctb_issues$authors [index, ]
 
         index <- which (
-            !ctb_issues$contributors$login %in%
-                c (ctb_code$logins, ctb_issues$authors$login)
+            !ctb_issues$contributors$logins %in%
+                c (ctb_code$logins, ctb_issues$authors$logins)
         )
         ctb_issues$contributors <- ctb_issues$contributors [index, ]
 


### PR DESCRIPTION
Hi @mpadge, thanks for the awesome package!
I just noticed I get some `"partial match"` warnings when running e.g. `get_contributors()`:

```r
Warning messages:
1: In ctb_code$login : partial match of 'login' to 'logins'
2: In ctb_issues$authors$login : partial match of 'login' to 'logins'
3: In ctb_issues$contributors$login : partial match of 'login' to 'logins'
4: In ctb_issues$authors$login : partial match of 'login' to 'logins'
```

(Note: I do have `options(warnPartialMatchDollar = TRUE, warnPartialMatchAttr = TRUE, warnPartialMatchArgs = TRUE)` set locally but I'd argue it's safer to not rely on partial matches 🙂).

This PR should take care of that. Happy to address any feedback or even for you to ignore this if you don't think it's important! 