### PR TITLE
fix: bug in implementation of `alphabetical` argument

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -137,7 +137,7 @@ get_gh_code_contributors <- function (org, repo, alphabetical = FALSE) {
     )
 
     if (alphabetical) {
-        out [order (res$login), ]
+        out [order (out$logins), ]
     } else {
         out
     }


### PR DESCRIPTION
Thanks for a great package.
While trying the `alphabetical` argument I ran into an error 
```
> allcontributors::add_contributors(alphabetical = TRUE)
*  Extracting code contributorsError in order(res$login) : argument 1 is not a vector
```
which I was able to resolve with the change in this simple Pull Request.
Please close and fix some other way if I'm off-base in what the solution should be.